### PR TITLE
Add upload file data lambda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
       repo-name: tdr-file-upload-data
       artifact-name: function
       artifact-file-type: zip
+      artifact-path: .
       build-command: |
         pip install --target ./package -r requirements-runtime.txt
         cp src/lambda_handler.py package/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add-upload-file-data-lambda
 jobs:
   pre-deploy:
     uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@main
@@ -27,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }} --ref add-upload-file-data-lambda
+      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}
+      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }} --ref add-upload-file-data-lambda
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
+      - add-upload-file-data-lambda
 jobs:
   pre-deploy:
     uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: TDR Tag and pre deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  pre-deploy:
+    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@main
+    with:
+      repo-name: tdr-file-upload-data
+      artifact-name: function
+      artifact-file-type: zip
+      build-command: |
+        pip install --target ./package -r requirements-runtime.txt
+        cp src/lambda_handler.py package/
+        cd package
+        zip -r ../function.zip .
+        cd ..
+    secrets:
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+  deploy:
+    needs: pre-deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: TDR Deploy File Upload Data Lambda
 on:
+  push:
+    branches:
+      - add-upload-file-data-lambda
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: TDR Deploy File Upload Data Lambda
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'
+        required: true
+        default: 'intg'
+      to-deploy:
+        description: 'Version to deploy'
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  deploy:
+    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_deploy.yml@main
+    with:
+      lambda-name: file-upload-data
+      deployment-package: function.zip
+      environment: ${{ github.event.inputs.environment }}
+      to-deploy: ${{ github.event.inputs.to-deploy }}
+    secrets:
+      ACCOUNT_NUMBER: ${{ secrets.ACCOUNT_NUMBER }}
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,5 @@
 name: TDR Deploy File Upload Data Lambda
 on:
-  push:
-    branches:
-      - add-upload-file-data-lambda
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       repo-name: tdr-antivirus
       test-command: |
-        pip install pyOpenSSL
+        pip install pyOpenSSL --upgrade
         pip install -r requirements.txt
         python -m pytest
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,28 @@
-name: TDR Run Lambda Tests
+name: TDR Run File Upload Data Tests
 on:
   pull_request:
   push:
     branches-ignore:
-      - master
+      - main
       - release-*
 permissions:
   id-token: write
   contents: read
 jobs:
   test:
-    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@main
-    with:
-      repo-name: tdr-antivirus
-      test-command: |
-        pip install pyOpenSSL --upgrade
-        pip install -r requirements.txt
-        python -m pytest
-    secrets:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
+      - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        if: failure()
+        with:
+          message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - run: |
+          pip install pyOpenSSL --upgrade
+          pip install -r requirements.txt
+          python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       repo-name: tdr-antivirus
       test-command: |
+        pip install pyOpenSSL
         pip install -r requirements.txt
         python -m pytest
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: TDR Run Lambda Tests
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+      - release-*
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  test:
+    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@main
+    with:
+      repo-name: tdr-antivirus
+      test-command: |
+        pip install -r requirements.txt
+        python -m pytest
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv
+package
+function.zip
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # TDR File Upload Data
+
+This is the replacement for the tdr-download files lambda. 
+It recieves `{"consignmentId": "xxxx-xxxx-xxxx", "userId": "xxxx-xxxx-xxxx"}` as input and then:
+
+* Calls the API to get a list of fileIds and original path data
+* Gets the list of files from S3
+* Compares the two and throws an error if there is a mismatch
+* Returns `[{"fileId": "xxxx-xxxx-xxxx" , "originalPath": "/original/file/path", "userId": "xxxx-xxxx-xxxx"}]`
+This array will then be passed to the map function in the step function which will call each of the backend checks in turn.
+  
+## Running locally
+You will need credentials for the AWS environment you are running this for set either as environment variables in the debug configuration or as a profile in `~/.aws/credentials`
+
+In the [lambda_runner](src/lambda_runner.py) file, replace the `user_id` and `consignment_id` variables with valid values.
+
+Set the following environment variables. These are for integration but can be replaced for other environments. 
+```
+CLIENT_SECRET_PATH=/intg/keycloak/backend_checks_client/secret
+AUTH_URL=https://auth.tdr-integration.nationalarchives.gov.uk
+CLIENT_ID=tdr-backend-checks
+API_URL=https://api.tdr-integration.nationalarchives.gov.uk/graphql
+BUCKET_NAME=tdr-upload-files-cloudfront-dirty-intg
+```
+Run `lambda_runner.py`
+
+## Running the tests
+The tests can be run in PyCharm by creating [a pytest configuration](https://www.jetbrains.com/help/pycharm/run-debug-configuration-py-test.html).
+
+They can also be run in the terminal. You need python3.9 running on your system.
+```bash
+python3.9 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python -m pytest 
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It recieves `{"consignmentId": "xxxx-xxxx-xxxx", "userId": "xxxx-xxxx-xxxx"}` as
 * Calls the API to get a list of fileIds and original path data
 * Gets the list of files from S3
 * Compares the two and throws an error if there is a mismatch
-* Returns `[{"fileId": "xxxx-xxxx-xxxx" , "originalPath": "/original/file/path", "userId": "xxxx-xxxx-xxxx"}]`
+* Returns `[{"consignmentId": "xxxx-xxxx-xxxx", "fileId": "xxxx-xxxx-xxxx" , "originalPath": "/original/file/path", "userId": "xxxx-xxxx-xxxx"}]`
 This array will then be passed to the map function in the step function which will call each of the backend checks in turn.
   
 ## Running locally

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,2 @@
+sgqlc
+requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+moto
+pyyaml

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest
 moto
 pyyaml
+boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Load all runtime and dev packages
+-r requirements-runtime.txt
+-r requirements-test.txt

--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -1,0 +1,102 @@
+from sgqlc.endpoint.http import HTTPEndpoint
+from sgqlc.operation import Operation
+from sgqlc.types.relay import Connection
+from sgqlc.types import Type, Field, list_of
+from boto3 import client
+import os
+import requests
+
+
+class FileMetadata(Type):
+    name = Field(str)
+    value = Field(str)
+
+
+class File(Type):
+    fileId = Field(str)
+    fileType = Field(str)
+    fileMetadata = list_of(FileMetadata)
+
+
+class Consignment(Connection):
+    files = list_of(File)
+
+
+class Query(Type):
+    getConsignment = Field(Consignment, args={'consignmentid': str})
+
+
+def get_client_secret():
+    client_secret_path = os.environ["CLIENT_SECRET_PATH"]
+    ssm_client = client("ssm")
+    response = ssm_client.get_parameter(
+        Name=client_secret_path,
+        WithDecryption=True
+    )
+    return response["Parameter"]["Value"]
+
+
+def get_token(client_secret):
+    client_id = os.environ["CLIENT_ID"]
+    auth_url = f'{os.environ["AUTH_URL"]}/realms/tdr/protocol/openid-connect/token'
+    grant_type = {"grant_type": "client_credentials"}
+    auth_response = requests.post(auth_url, data=grant_type, auth=(client_id, client_secret))
+    if auth_response.status_code != 200:
+        raise RuntimeError(f"Non 200 status from Keycloak {auth_response.status_code}")
+    return auth_response.json()['access_token']
+
+
+def get_query(consignment_id):
+    operation = Operation(Query)
+    consignment = operation.getConsignment(consignmentid=consignment_id)
+    files = consignment.files()
+    files.fileId()
+    files.fileType()
+    files.fileMetadata()
+    return operation
+
+
+def process_file(file: File):
+    file_path = [data['value'] for data in file.fileMetadata if data.name == "ClientSideOriginalFilepath"][0]
+    return {'fileId': file.fileId, 'originalPath': file_path}
+
+
+def s3_list_files(prefix):
+    s3_client = client("s3")
+    truncated = True
+    marker = ''
+    response = None
+    while truncated:
+        response = s3_client.list_objects(
+            Bucket=os.environ['BUCKET_NAME'],
+            Prefix=prefix,
+            Marker=marker
+        )
+        truncated = response["IsTruncated"]
+        marker = response['Marker'] if truncated else ''
+    return [entry["Key"].split("/")[2] for entry in response["Contents"]]
+
+
+def validate_all_files_uploaded(prefix, consignment: Consignment):
+    api_files = [file.fileId for file in consignment.files if file.fileType == "File"]
+    s3_files = s3_list_files(prefix)
+    api_files.sort()
+    s3_files.sort()
+    if api_files != s3_files:
+        raise RuntimeError(f"Uploaded files do not match files from the API for {prefix}")
+
+
+def handler(event, lambda_context):
+    user_id = event["userId"]
+    consignment_id = event["consignmentId"]
+    query = get_query(consignment_id)
+    client_secret = get_client_secret()
+    api_url = os.environ["API_URL"]
+    headers = {'Authorization': f'Bearer {get_token(client_secret)}'}
+    endpoint = HTTPEndpoint(api_url, headers, 300)
+    data = endpoint(query)
+    if 'errors' in data:
+        raise Exception("Error in response", data['errors'])
+    consignment = (query + data).getConsignment
+    validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
+    return [process_file(file) | {'userId': user_id} for file in consignment.files]

--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -99,4 +99,4 @@ def handler(event, lambda_context):
         raise Exception("Error in response", data['errors'])
     consignment = (query + data).getConsignment
     validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
-    return [process_file(file) | {'consignmentId': consignment_id ,'userId': user_id} for file in consignment.files]
+    return [process_file(file) | {'consignmentId': consignment_id, 'userId': user_id} for file in consignment.files]

--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -99,4 +99,4 @@ def handler(event, lambda_context):
         raise Exception("Error in response", data['errors'])
     consignment = (query + data).getConsignment
     validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
-    return [process_file(file) | {'userId': user_id} for file in consignment.files]
+    return [process_file(file) | {'consignmentId': consignment_id ,'userId': user_id} for file in consignment.files]

--- a/src/lambda_runner.py
+++ b/src/lambda_runner.py
@@ -1,0 +1,5 @@
+import lambda_handler
+user_id = '030cf12c-8d5d-46b9-b86a-38e0920d0e1a'
+consignment_id = 'e7073993-0bed-4d5f-bb2a-5bea1b2a87d3'
+event = {'userId': user_id, 'consignmentId': consignment_id}
+lambda_handler.handler(event, None)

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -36,9 +36,11 @@ def test_files_are_returned(mock_url_open, ssm, s3):
         assert file_one["fileId"] == "13702546-da63-4545-a9eb-a892df1aafba"
         assert file_one["originalPath"] == "testfile/subfolder/subfolder2.txt"
         assert file_one["userId"] == user_id
+        assert file_one["consignmentId"] == consignment_id
         assert file_two["fileId"] == "1c2b9eeb-2e4c-4cfc-bc08-c193660f86d2"
         assert file_two["originalPath"] == "testfile/subfolder/subfolder1.txt"
         assert file_two["userId"] == user_id
+        assert file_two["consignmentId"] == consignment_id
 
 
 @patch('urllib.request.urlopen')

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,0 +1,90 @@
+import urllib
+from unittest.mock import patch
+import pytest
+from moto import mock_ssm, mock_s3
+import boto3
+from src import lambda_handler
+from tests.utils.utils import *
+
+
+@pytest.fixture(scope='function')
+def ssm():
+    with mock_ssm():
+        yield boto3.client('ssm', region_name='eu-west-2')
+
+
+@pytest.fixture(scope='function')
+def s3():
+    with mock_s3():
+        yield boto3.client('s3', region_name='eu-west-2')
+
+
+@patch('urllib.request.urlopen')
+def test_files_are_returned(mock_url_open, ssm, s3):
+    setup_env_vars()
+    setup_ssm(ssm)
+    setup_s3(s3)
+    configure_mock_urlopen(mock_url_open, graphql_ok_multiple_files)
+    event = {'userId': user_id, 'consignmentId': consignment_id}
+    with patch('src.lambda_handler.requests.post') as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json = access_token
+        response = lambda_handler.handler(event, None)
+        response.sort(key=sort_by_id)
+        file_one = response[0]
+        file_two = response[1]
+        assert file_one["fileId"] == "13702546-da63-4545-a9eb-a892df1aafba"
+        assert file_one["originalPath"] == "testfile/subfolder/subfolder2.txt"
+        assert file_one["userId"] == user_id
+        assert file_two["fileId"] == "1c2b9eeb-2e4c-4cfc-bc08-c193660f86d2"
+        assert file_two["originalPath"] == "testfile/subfolder/subfolder1.txt"
+        assert file_two["userId"] == user_id
+
+
+@patch('urllib.request.urlopen')
+def test_error_from_graphql_api(mock_url_open, ssm, s3):
+    setup_env_vars()
+    setup_ssm(ssm)
+    setup_s3(s3)
+    err = urllib.error.HTTPError(
+        'http://testserver.com',
+        500,
+        'Some Error',
+        {'Xpto': 'abc'},
+        io.BytesIO(b'xpto'),
+    )
+    event = {'userId': user_id, 'consignmentId': consignment_id}
+    configure_mock_urlopen(mock_url_open, err)
+    with patch('src.lambda_handler.requests.post') as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json = access_token
+        with pytest.raises(Exception) as ex:
+            lambda_handler.handler(event, None)
+        assert ex.value.args[1][0]['message'] == 'HTTP Error 500: Some Error'
+
+
+def test_error_from_keycloak(ssm, s3):
+    setup_env_vars()
+    setup_ssm(ssm)
+    setup_s3(s3)
+    event = {'userId': user_id, 'consignmentId': consignment_id}
+    with patch('src.lambda_handler.requests.post') as mock_post:
+        mock_post.return_value.status_code = 500
+        with pytest.raises(RuntimeError) as ex:
+            lambda_handler.handler(event, None)
+        assert ex.value.args[0] == 'Non 200 status from Keycloak 500'
+
+
+@patch('urllib.request.urlopen')
+def test_error_if_s3_files_mismatch(mock_url_open, ssm, s3):
+    setup_env_vars()
+    setup_ssm(ssm)
+    setup_s3(s3, missing_file_id)
+    event = {'userId': user_id, 'consignmentId': consignment_id}
+    configure_mock_urlopen(mock_url_open, graphql_ok_multiple_files)
+    with patch('src.lambda_handler.requests.post') as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json = access_token
+        with pytest.raises(RuntimeError) as ex:
+            lambda_handler.handler(event, None)
+        assert ex.value.args[0] == f'Uploaded files do not match files from the API for {user_id}/{consignment_id}'

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -80,6 +80,7 @@ def setup_env_vars():
     os.environ["CLIENT_ID"] = "id"
     os.environ["API_URL"] = "http://localhost"
     os.environ["BUCKET_NAME"] = "test-bucket"
+    os.environ['AWS_DEFAULT_REGION'] = 'eu-west-2'
 
 
 def sort_by_id(file):

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -1,0 +1,86 @@
+import os
+import io
+
+user_id = '030cf12c-8d5d-46b9-b86a-38e0920d0e1a'
+consignment_id = 'e7073993-0bed-4d5f-bb2a-5bea1b2a87d3'
+all_file_ids = ['1c2b9eeb-2e4c-4cfc-bc08-c193660f86d2', '13702546-da63-4545-a9eb-a892df1aafba']
+missing_file_id = ['13702546-da63-4545-a9eb-a892df1aafba']
+
+graphql_ok_multiple_files = b'''{
+  "data": {
+    "getConsignment": {
+      "files": [
+        {
+          "fileId": "1c2b9eeb-2e4c-4cfc-bc08-c193660f86d2",
+          "fileType": "File",
+          "fileMetadata": [
+            {
+              "name": "ClientSideOriginalFilepath",
+              "value": "testfile/subfolder/subfolder1.txt"
+            }
+          ]
+        },
+        {
+          "fileId": "13702546-da63-4545-a9eb-a892df1aafba",
+          "fileType": "File",
+          "fileMetadata": [
+            {
+              "name": "ClientSideOriginalFilepath",
+              "value": "testfile/subfolder/subfolder2.txt"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+'''
+
+
+def setup_ssm(ssm):
+    ssm.put_parameter(
+        Name="/test/client/secret",
+        Description="description",
+        Value="client-secret",
+        Type="SecureString",
+        Overwrite=True,
+    )
+
+
+def setup_s3(s3, file_ids=None):
+    if file_ids is None:
+        file_ids = all_file_ids
+    s3.create_bucket(Bucket='test-bucket',
+                     CreateBucketConfiguration={
+                         'LocationConstraint': 'eu-west-2',
+                     })
+    for file_id in file_ids:
+        s3.delete_object(Bucket="test-bucket", Key=f"{user_id}/{consignment_id}/{file_id}")
+        s3.put_object(
+            Body=b'filetoupload',
+            Bucket='test-bucket',
+            Key=f"{user_id}/{consignment_id}/{file_id}",
+        )
+
+
+def configure_mock_urlopen(mock_urlopen, payload):
+    if isinstance(payload, Exception):
+        mock_urlopen.side_effect = payload
+    else:
+        mock_urlopen.return_value = io.BytesIO(payload)
+
+
+def access_token():
+    return {'access_token': 'ABCD'}
+
+
+def setup_env_vars():
+    os.environ["CLIENT_SECRET_PATH"] = "/test/client/secret"
+    os.environ["AUTH_URL"] = "http://localhost"
+    os.environ["CLIENT_ID"] = "id"
+    os.environ["API_URL"] = "http://localhost"
+    os.environ["BUCKET_NAME"] = "test-bucket"
+
+
+def sort_by_id(file):
+    return file["fileId"]


### PR DESCRIPTION
This is the replacement for tdr-download files. It recieves this `{"consignmentId": "xxxx-xxxx-xxxx", "userId": "xxxx-xxxx-xxxx"}` as input and then:
* Calls the API to get a list of fileIds and original path data
* Gets the list of files from S3
* Compares the two and throws an error if there is a mismatch
* Returns `[{"fileId": "xxxx-xxxx-xxxx" , "originalPath": "/original/file/path", "userId": "xxxx-xxxx-xxxx"}]`

This array will then be passed to the map function in the step function which will call each of the backend checks in turn.

