### PR TITLE
Add more metadata to the output.

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -107,5 +107,7 @@ def handler(event, lambda_context):
         raise Exception("Error in response", data['errors'])
     consignment = (query + data).getConsignment
     validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
-    return [process_file(file) | {'consignmentId': consignment_id, 'userId': user_id} for file in consignment.files
-            if file.fileType == "File"]
+    return {
+        "results": [process_file(file) | {'consignmentId': consignment_id, 'userId': user_id}
+                    for file in consignment.files if file.fileType == "File"]
+    }

--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -20,6 +20,7 @@ class File(Type):
 
 class Consignment(Connection):
     files = list_of(File)
+    consignmentType = Field(str)
 
 
 class Query(Type):
@@ -49,6 +50,7 @@ def get_token(client_secret):
 def get_query(consignment_id):
     operation = Operation(Query)
     consignment = operation.getConsignment(consignmentid=consignment_id)
+    consignment.consignmentType()
     files = consignment.files()
     files.fileId()
     files.fileType()
@@ -108,6 +110,7 @@ def handler(event, lambda_context):
     consignment = (query + data).getConsignment
     validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
     return {
-        "results": [process_file(file) | {'consignmentId': consignment_id, 'userId': user_id}
+        "results": [process_file(file) |
+                    {'consignmentType': consignment.consignmentType, 'consignmentId': consignment_id, 'userId': user_id}
                     for file in consignment.files if file.fileType == "File"]
     }

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -29,7 +29,7 @@ def test_files_are_returned(mock_url_open, ssm, s3):
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 200
         mock_post.return_value.json = access_token
-        response = lambda_handler.handler(event, None)
+        response = lambda_handler.handler(event, None)["results"]
         response.sort(key=sort_by_id)
         file_one = response[0]
         file_two = response[1]

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -17,6 +17,14 @@ graphql_ok_multiple_files = b'''{
             {
               "name": "ClientSideOriginalFilepath",
               "value": "testfile/subfolder/subfolder1.txt"
+            },
+            {
+              "name": "SHA256ClientSideChecksum",
+              "value": "achecksum"
+            },
+            {
+              "name": "ClientSideFileSize",
+              "value": "0"
             }
           ]
         },
@@ -27,6 +35,14 @@ graphql_ok_multiple_files = b'''{
             {
               "name": "ClientSideOriginalFilepath",
               "value": "testfile/subfolder/subfolder2.txt"
+            },
+            {
+              "name": "SHA256ClientSideChecksum",
+              "value": "achecksum"
+            },
+            {
+              "name": "ClientSideFileSize",
+              "value": "0"
             }
           ]
         }

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -9,6 +9,7 @@ missing_file_id = ['13702546-da63-4545-a9eb-a892df1aafba']
 graphql_ok_multiple_files = b'''{
   "data": {
     "getConsignment": {
+      "consignmentType": "standard",
       "files": [
         {
           "fileId": "1c2b9eeb-2e4c-4cfc-bc08-c193660f86d2",


### PR DESCRIPTION
If we add the file size and the client checksum then we can check for
file statuses within the step function.
