### PR TITLE
Add consignment status to the output.

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -96,6 +96,16 @@ def validate_all_files_uploaded(prefix, consignment: Consignment):
         raise RuntimeError(f"Uploaded files do not match files from the API for {prefix}")
 
 
+def consignment_statuses(consignment_id, status_name, status_value='InProgress'):
+    return {
+        "id": consignment_id,
+        "statusType": "Consignment",
+        "statusName": status_name,
+        "statusValue": status_value,
+        "overwrite": False
+    }
+
+
 def handler(event, lambda_context):
     user_id = event["userId"]
     consignment_id = event["consignmentId"]
@@ -109,17 +119,11 @@ def handler(event, lambda_context):
         raise Exception("Error in response", data['errors'])
     consignment = (query + data).getConsignment
     validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
+    status_names = ['ServerFFID', 'ServerChecksum', 'ServerAntivirus']
     return {
         "results": [process_file(file) |
                     {'consignmentType': consignment.consignmentType, 'consignmentId': consignment_id, 'userId': user_id}
                     for file in consignment.files if file.fileType == "File"],
-        "statuses": [
-            {
-                "id": consignment_id,
-                "statusType": "Consignment",
-                "statusName": "ServerFFID",
-                "statusValue": "InProgress",
-                "overwrite": False
-            }
-        ]
+
+        "statuses": [consignment_statuses(consignment_id, status_name) for status_name in status_names]
     }

--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -112,5 +112,14 @@ def handler(event, lambda_context):
     return {
         "results": [process_file(file) |
                     {'consignmentType': consignment.consignmentType, 'consignmentId': consignment_id, 'userId': user_id}
-                    for file in consignment.files if file.fileType == "File"]
+                    for file in consignment.files if file.fileType == "File"],
+        "statuses": [
+            {
+                "id": consignment_id,
+                "statusType": "Consignment",
+                "statusName": "ServerFFID",
+                "statusValue": "InProgress",
+                "overwrite": False
+            }
+        ]
     }

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -29,10 +29,11 @@ def test_files_are_returned(mock_url_open, ssm, s3):
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 200
         mock_post.return_value.json = access_token
-        response = lambda_handler.handler(event, None)["results"]
-        response.sort(key=sort_by_id)
-        file_one = response[0]
-        file_two = response[1]
+        response = lambda_handler.handler(event, None)
+        results = response["results"]
+        results.sort(key=sort_by_id)
+        file_one = results[0]
+        file_two = results[1]
         assert file_one["fileId"] == "13702546-da63-4545-a9eb-a892df1aafba"
         assert file_one["originalPath"] == "testfile/subfolder/subfolder2.txt"
         assert file_one["userId"] == user_id
@@ -41,6 +42,14 @@ def test_files_are_returned(mock_url_open, ssm, s3):
         assert file_two["originalPath"] == "testfile/subfolder/subfolder1.txt"
         assert file_two["userId"] == user_id
         assert file_two["consignmentId"] == consignment_id
+
+        statuses = response["statuses"]
+        statuses.sort(key=lambda x: x["id"])
+        status_one = statuses[0]
+        assert status_one["id"] == consignment_id
+        assert status_one["statusType"] == "Consignment"
+        assert status_one["statusName"] == "ServerFFID"
+        assert status_one["statusValue"] == "InProgress"
 
 
 @patch('urllib.request.urlopen')

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -19,6 +19,13 @@ def s3():
         yield boto3.client('s3', region_name='eu-west-2')
 
 
+def check_statuses(status, status_name, status_id):
+    assert status["id"] == status_id
+    assert status["statusType"] == "Consignment"
+    assert status["statusName"] == status_name
+    assert status["statusValue"] == "InProgress"
+
+
 @patch('urllib.request.urlopen')
 def test_files_are_returned(mock_url_open, ssm, s3):
     setup_env_vars()
@@ -44,12 +51,11 @@ def test_files_are_returned(mock_url_open, ssm, s3):
         assert file_two["consignmentId"] == consignment_id
 
         statuses = response["statuses"]
+        assert len(statuses) == 3
         statuses.sort(key=lambda x: x["id"])
-        status_one = statuses[0]
-        assert status_one["id"] == consignment_id
-        assert status_one["statusType"] == "Consignment"
-        assert status_one["statusName"] == "ServerFFID"
-        assert status_one["statusValue"] == "InProgress"
+        check_statuses(statuses[0], "ServerFFID", consignment_id)
+        check_statuses(statuses[1], "ServerChecksum", consignment_id)
+        check_statuses(statuses[2], "ServerAntivirus", consignment_id)
 
 
 @patch('urllib.request.urlopen')


### PR DESCRIPTION
This is then passed to the API update lambda in the step function to update the consignment status to InProgress for the ServerFFID, ServerAntivirus and ServerChecksum.

These tickets cover the three statuses
https://national-archives.atlassian.net/browse/TDR-2113
https://national-archives.atlassian.net/browse/TDR-2114
https://national-archives.atlassian.net/browse/TDR-2115
