### PR TITLE
Add outer statuses block.

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -125,5 +125,7 @@ def handler(event, lambda_context):
                     {'consignmentType': consignment.consignmentType, 'consignmentId': consignment_id, 'userId': user_id}
                     for file in consignment.files if file.fileType == "File"],
 
-        "statuses": [consignment_statuses(consignment_id, status_name) for status_name in status_names]
+        "statuses": {
+            "statuses": [consignment_statuses(consignment_id, status_name) for status_name in status_names]
+        }
     }

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -50,7 +50,7 @@ def test_files_are_returned(mock_url_open, ssm, s3):
         assert file_two["userId"] == user_id
         assert file_two["consignmentId"] == consignment_id
 
-        statuses = response["statuses"]
+        statuses = response["statuses"]["statuses"]
         assert len(statuses) == 3
         statuses.sort(key=lambda x: x["id"])
         check_statuses(statuses[0], "ServerFFID", consignment_id)


### PR DESCRIPTION
Manipulating json inside the step functions can be a bit tricky so I've
ended up with a structure like
```
{
  "statuses": [{
    "statuses" : {}
  }]
```
This is a bit annoying but this seems to be the only thing that works.
