### PR TITLE
Get the userId from the API.

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -21,6 +21,7 @@ class File(Type):
 class Consignment(Connection):
     files = list_of(File)
     consignmentType = Field(str)
+    userid = Field(str)
 
 
 class Query(Type):
@@ -51,6 +52,7 @@ def get_query(consignment_id):
     operation = Operation(Query)
     consignment = operation.getConsignment(consignmentid=consignment_id)
     consignment.consignmentType()
+    consignment.userid()
     files = consignment.files()
     files.fileId()
     files.fileType()
@@ -107,7 +109,6 @@ def consignment_statuses(consignment_id, status_name, status_value='InProgress')
 
 
 def handler(event, lambda_context):
-    user_id = event["userId"]
     consignment_id = event["consignmentId"]
     query = get_query(consignment_id)
     client_secret = get_client_secret()
@@ -118,6 +119,7 @@ def handler(event, lambda_context):
     if 'errors' in data:
         raise Exception("Error in response", data['errors'])
     consignment = (query + data).getConsignment
+    user_id = consignment.userid
     validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
     status_names = ['ServerFFID', 'ServerChecksum', 'ServerAntivirus']
     return {

--- a/src/lambda_runner.py
+++ b/src/lambda_runner.py
@@ -1,5 +1,4 @@
 import lambda_handler
-user_id = '030cf12c-8d5d-46b9-b86a-38e0920d0e1a'
 consignment_id = 'e7073993-0bed-4d5f-bb2a-5bea1b2a87d3'
-event = {'userId': user_id, 'consignmentId': consignment_id}
+event = {'consignmentId': consignment_id}
 lambda_handler.handler(event, None)

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -32,7 +32,7 @@ def test_files_are_returned(mock_url_open, ssm, s3):
     setup_ssm(ssm)
     setup_s3(s3)
     configure_mock_urlopen(mock_url_open, graphql_ok_multiple_files)
-    event = {'userId': user_id, 'consignmentId': consignment_id}
+    event = {'consignmentId': consignment_id}
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 200
         mock_post.return_value.json = access_token
@@ -70,7 +70,7 @@ def test_error_from_graphql_api(mock_url_open, ssm, s3):
         {'Xpto': 'abc'},
         io.BytesIO(b'xpto'),
     )
-    event = {'userId': user_id, 'consignmentId': consignment_id}
+    event = {'consignmentId': consignment_id}
     configure_mock_urlopen(mock_url_open, err)
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 200
@@ -84,7 +84,7 @@ def test_error_from_keycloak(ssm, s3):
     setup_env_vars()
     setup_ssm(ssm)
     setup_s3(s3)
-    event = {'userId': user_id, 'consignmentId': consignment_id}
+    event = {'consignmentId': consignment_id}
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 500
         with pytest.raises(RuntimeError) as ex:
@@ -96,7 +96,7 @@ def test_error_from_keycloak(ssm, s3):
 def test_error_if_s3_download_error(mock_url_open, ssm, s3):
     setup_env_vars()
     setup_ssm(ssm)
-    event = {'userId': user_id, 'consignmentId': consignment_id}
+    event = {'consignmentId': consignment_id}
     configure_mock_urlopen(mock_url_open, graphql_ok_multiple_files)
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 200
@@ -112,7 +112,7 @@ def test_error_if_s3_files_mismatch(mock_url_open, ssm, s3):
     setup_env_vars()
     setup_ssm(ssm)
     setup_s3(s3, missing_file_id)
-    event = {'userId': user_id, 'consignmentId': consignment_id}
+    event = {'consignmentId': consignment_id}
     configure_mock_urlopen(mock_url_open, graphql_ok_multiple_files)
     with patch('src.lambda_handler.requests.post') as mock_post:
         mock_post.return_value.status_code = 200

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -10,6 +10,7 @@ graphql_ok_multiple_files = b'''{
   "data": {
     "getConsignment": {
       "consignmentType": "standard",
+      "userid": "030cf12c-8d5d-46b9-b86a-38e0920d0e1a",
       "files": [
         {
           "fileId": "1c2b9eeb-2e4c-4cfc-bc08-c193660f86d2",


### PR DESCRIPTION
I want to be able to re-use the consignment api authoriser for the
backend checks API as they're doing the same job.

The authoriser needs to check the consignment id to make sure the user
is allowed access. The authoriser only has access to the request path
and has no access to the request body.

I was originally going to send the consignment id in the body along with
the user id. Because I want to re-use the export authoriser, I'll be
sending the consignment id in the path and it seems a bit pointless to
send the user_id on its own in the request body when it's available
easily from the API in this lambda.
