### PR TITLE
Return upload status.

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -94,8 +94,7 @@ def validate_all_files_uploaded(prefix, consignment: Consignment):
     s3_files = s3_list_files(prefix)
     api_files.sort()
     s3_files.sort()
-    if api_files != s3_files:
-        raise RuntimeError(f"Uploaded files do not match files from the API for {prefix}")
+    return api_files == s3_files
 
 
 def consignment_statuses(consignment_id, status_name, status_value='InProgress'):
@@ -120,14 +119,26 @@ def handler(event, lambda_context):
         raise Exception("Error in response", data['errors'])
     consignment = (query + data).getConsignment
     user_id = consignment.userid
-    validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
+    are_all_files_uploaded = validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
     status_names = ['ServerFFID', 'ServerChecksum', 'ServerAntivirus']
-    return {
-        "results": [process_file(file) |
-                    {'consignmentType': consignment.consignmentType, 'consignmentId': consignment_id, 'userId': user_id}
-                    for file in consignment.files if file.fileType == "File"],
+    statuses = [consignment_statuses(consignment_id, status_name) for status_name in status_names]
+    statuses.append(consignment_statuses(consignment_id, "Upload", "Completed"))
+    if are_all_files_uploaded:
+        return {
+            "results": [process_file(file) |
+                        {'consignmentType': consignment.consignmentType, 'consignmentId': consignment_id, 'userId': user_id}
+                        for file in consignment.files if file.fileType == "File"],
 
-        "statuses": {
-            "statuses": [consignment_statuses(consignment_id, status_name) for status_name in status_names]
+            "statuses": {
+                "statuses": statuses
+            }
         }
-    }
+    else:
+        return {
+            "results": [],
+            "statuses": {
+                "statuses": [
+                    consignment_statuses(consignment_id, "Upload", "CompletedWithIssues")
+                ]
+            }
+        }

--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -97,13 +97,13 @@ def validate_all_files_uploaded(prefix, consignment: Consignment):
     return api_files == s3_files
 
 
-def consignment_statuses(consignment_id, status_name, status_value='InProgress'):
+def consignment_statuses(consignment_id, status_name, status_value='InProgress', overwrite = False):
     return {
         "id": consignment_id,
         "statusType": "Consignment",
         "statusName": status_name,
         "statusValue": status_value,
-        "overwrite": False
+        "overwrite": overwrite
     }
 
 
@@ -122,7 +122,7 @@ def handler(event, lambda_context):
     are_all_files_uploaded = validate_all_files_uploaded(f"{user_id}/{consignment_id}", consignment)
     status_names = ['ServerFFID', 'ServerChecksum', 'ServerAntivirus']
     statuses = [consignment_statuses(consignment_id, status_name) for status_name in status_names]
-    statuses.append(consignment_statuses(consignment_id, "Upload", "Completed"))
+    statuses.append(consignment_statuses(consignment_id, "Upload", "Completed", True))
     if are_all_files_uploaded:
         return {
             "results": [process_file(file) |
@@ -138,7 +138,7 @@ def handler(event, lambda_context):
             "results": [],
             "statuses": {
                 "statuses": [
-                    consignment_statuses(consignment_id, "Upload", "CompletedWithIssues")
+                    consignment_statuses(consignment_id, "Upload", "CompletedWithIssues", True)
                 ]
             }
         }


### PR DESCRIPTION
We were getting the upload status from the file upload statuses. I've
changed this now so that if the number of files in S3 don't match what's
expected in the API, we return an `Upload` status of
`CompletedWithIssues` and no results, so the backend checks won't run
against the existing files.

If everything matched, an upload status of `Completed` is added to the
existing statuses.
