### PR TITLE
Add failures to inital json.

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -73,6 +73,7 @@ def process_file(file: File):
         'fileSize': get_metadata_value(file, "ClientSideFileSize"),
         "clientChecksum": get_metadata_value(file, "SHA256ClientSideChecksum"),
         "fileCheckResults": {
+            "failures": [],
             "antivirus": [],
             "checksum": [],
             "fileFormat": []


### PR DESCRIPTION
To prevent having `Option` everywhere in the circe case classes in the
Scala lambdas, this lambda sets all of the json that will be needed
further down.
This will be used to store the name of any file check lambdas which fail
so we can set the statuses appropriately.
