### PR TITLE
Fix issue

### DIFF
--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,2 +1,3 @@
 sgqlc
 requests
+urllib3<2


### PR DESCRIPTION
The latest version (2.0.2) of urllib3 is causing an issue - cannot import name 'default_ciphers' from 'urllib3.util.ssl_' (/opt/python/urllib3/util/ssl_.py)

Hence, downgrading urllib3 to <2 should fix the problem